### PR TITLE
Update 09-e2e-githubaction.md

### DIFF
--- a/Scenarios/ASA-Secure-Baseline/Terraform/09-e2e-githubaction.md
+++ b/Scenarios/ASA-Secure-Baseline/Terraform/09-e2e-githubaction.md
@@ -131,4 +131,4 @@ First we need to get the ingress URL by running the following command:
     --name api-gateway --query "properties.url" --output tsv    
 ```
 
-Then we can use `curl` to test our applications using the above endpoint. This assumes that there's no Application Gateway and you would access your spring app using the spring apps ingress url for the api-gateway app instance.
+Then we can use `curl` to test our applications using the above endpoint. This assumes that there's no Application Gateway and you would access your spring app using the spring apps ingress url for the api-gateway app instance. Since the applications are deployed in an internal only environment you would need to do the curl from a jumpbox or bastion host.


### PR DESCRIPTION
Clarify that curl to test the deployment needs to be done from the Bastion host in the absence of AppGW.