### PR TITLE
Add the tags on the hub resource group

### DIFF
--- a/Scenarios/ASA-Secure-Baseline/Terraform/02-Hub-Network/main.tf
+++ b/Scenarios/ASA-Secure-Baseline/Terraform/02-Hub-Network/main.tf
@@ -37,6 +37,7 @@ resource "azurerm_resource_group" "hub_rg" {
     name                        = local.hub_rg
     location                    = var.location
 
+    tags = var.tags
 }
 
 # Hub-Spoke VNET 


### PR DESCRIPTION
The tags are not on the hub resource group but on all hub resources. Added for consistency. Could be removed as the hub is normally shared and not linked to a workload.