### PR TITLE
Fixes for standard and enterprise deployment issues

### DIFF
--- a/.github/workflows/deploy_enterprise.yml
+++ b/.github/workflows/deploy_enterprise.yml
@@ -549,6 +549,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \

--- a/.github/workflows/deploy_enterprise.yml
+++ b/.github/workflows/deploy_enterprise.yml
@@ -349,6 +349,7 @@ jobs:
         run: |
             az spring app deploy \
                 --name catalog-service \
+                --build-env "BP_JVM_VERSION=17" \
                 --jvm-options='-XX:MaxMetaspaceSize=148644K' \
                 --source-path ${{ github.workspace }}/fitness-store/apps/acme-catalog \
                 --config-file-pattern catalog
@@ -356,6 +357,7 @@ jobs:
         run: |
             az spring app deploy \
                 --name payment-service \
+                --build-env "BP_JVM_VERSION=17" \
                 --jvm-options='-XX:MaxMetaspaceSize=148644K' \
                 --source-path ${{ github.workspace }}/fitness-store/apps/acme-payment \
                 --env "SPRING_DATASOURCE_AZURE_PASSWORDLESSENABLED=true" \

--- a/.github/workflows/deploy_enterprise.yml
+++ b/.github/workflows/deploy_enterprise.yml
@@ -87,6 +87,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \

--- a/.github/workflows/deploy_enterprise.yml
+++ b/.github/workflows/deploy_enterprise.yml
@@ -371,7 +371,7 @@ jobs:
         run: |
             az spring app deploy \
                 --name cart-service \
-                --env -CART_PORT 8080 \
+                --env "CART_PORT=8080" \
                 --source-path ${{ github.workspace }}/fitness-store/apps/acme-cart                 
       - name: Deploy apps/acme-shopping
         run: |

--- a/.github/workflows/deploy_enterprise.yml
+++ b/.github/workflows/deploy_enterprise.yml
@@ -176,6 +176,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \

--- a/.github/workflows/deploy_enterprise.yml
+++ b/.github/workflows/deploy_enterprise.yml
@@ -338,69 +338,44 @@ jobs:
         uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Set up Azure Spring Extension
+        run: |
+            az extension add --name spring 
+            az account set --subscription ${{ env.ARM_SUBSCRIPTION_ID }} 
+            az configure --defaults group=${{ env.SPRING_APPS_RESOURCE_GROUP }} spring=${{env.SPRING_APPS_SERVICE_NAME}} 
+      - name: Deploy apps/acme-catalog
+        run: |
+            az spring app deploy \
+                --name catalog-service \
+                --build-env "-BP_JVM_VERSION 17" \
+                --jvm-options='-XX:MaxMetaspaceSize=148644K' \
+                --source-path ${{ github.workspace }}/fitness-store/apps/acme-catalog \
+                --config-file-pattern catalog
       - name: Deploy apps/acme-payment
-        uses: azure/spring-apps-deploy@v1
-        if: needs.conditions.outputs.destroy == 'false'
-        with:
-          azure-subscription: ${{ env.ARM_SUBSCRIPTION_ID }}
-          action: deploy
-          service-name: ${{ env.SPRING_APPS_SERVICE_NAME }}
-          app-name: payment-service
-          use-staging-deployment: false
-          package: ${{ github.workspace }}/fitness-store/apps/acme-payment
-          jvm-options: -Xms2048m -Xmx2048m
-          runtime-version: Java_17
-          build-env: "-BP_JVM_VERSION 17"
-          config-file-patterns: payment
-
-      - name: Deploy catalog service
-        uses: azure/spring-apps-deploy@v1
-        if: needs.conditions.outputs.destroy == 'false'
-        with:
-          azure-subscription: ${{ env.ARM_SUBSCRIPTION_ID }}
-          action: deploy
-          service-name: ${{ env.SPRING_APPS_SERVICE_NAME }}
-          app-name: catalog-service
-          use-staging-deployment: false
-          package: ${{ github.workspace }}/fitness-store/apps/acme-catalog
-          jvm-options: -Xms2048m -Xmx2048m
-          runtime-version: Java_17
-          build-env: "-BP_JVM_VERSION 17"
-          config-file-patterns: catalog
-
+        run: |
+            az spring app deploy \
+                --name payment-service \
+                --build-env "-BP_JVM_VERSION 17" \
+                --jvm-options='-XX:MaxMetaspaceSize=148644K' \
+                --source-path ${{ github.workspace }}/fitness-store/apps/acme-payment \
+                --env "SPRING_DATASOURCE_AZURE_PASSWORDLESSENABLED=true" \
+                --config-file-pattern payment
       - name: Deploy apps/acme-order
-        uses: azure/spring-apps-deploy@v1
-        if: needs.conditions.outputs.destroy == 'false'
-        with:
-          azure-subscription: ${{ env.ARM_SUBSCRIPTION_ID }}
-          action: deploy
-          service-name: ${{ env.SPRING_APPS_SERVICE_NAME }}
-          app-name: order-service
-          use-staging-deployment: false
-          package: ${{ github.workspace }}/fitness-store/apps/acme-order
-
+        run: |
+            az spring app deploy \
+                --name order-service \
+                --source-path ${{ github.workspace }}/fitness-store/apps/acme-order 
       - name: Deploy apps/acme-cart 
-        uses: azure/spring-apps-deploy@v1
-        if: needs.conditions.outputs.destroy == 'false'
-        with:
-          azure-subscription: ${{ env.ARM_SUBSCRIPTION_ID }}
-          action: deploy
-          service-name: ${{ env.SPRING_APPS_SERVICE_NAME }}
-          app-name: cart-service
-          use-staging-deployment: false
-          package: ${{ github.workspace }}/fitness-store/apps/acme-cart 
-          environment-variables: -CART_PORT 8080
-
+        run: |
+            az spring app deploy \
+                --name cart-service \
+                --env -CART_PORT 8080 \
+                --source-path ${{ github.workspace }}/fitness-store/apps/acme-cart                 
       - name: Deploy apps/acme-shopping
-        uses: azure/spring-apps-deploy@v1
-        if: needs.conditions.outputs.destroy == 'false'
-        with:
-          azure-subscription: ${{ env.ARM_SUBSCRIPTION_ID }}
-          action: deploy
-          service-name: ${{ env.SPRING_APPS_SERVICE_NAME }}
-          app-name: frontend
-          use-staging-deployment: false
-          package: ${{ github.workspace }}/fitness-store/apps/acme-shopping
+        run: |
+            az spring app deploy \
+                --name frontend \
+                --source-path ${{ github.workspace }}/fitness-store/apps/acme-shopping
   prepare_destroy:
     needs: [conditions, build, deploy_lz_enterprise, deploy_lz_shared]
     name: Prepare Spring Enterprise for Destroy

--- a/.github/workflows/deploy_enterprise.yml
+++ b/.github/workflows/deploy_enterprise.yml
@@ -130,6 +130,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \
@@ -220,6 +221,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \
@@ -261,6 +263,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \
@@ -303,6 +306,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \
@@ -437,6 +441,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \
@@ -474,6 +479,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \
@@ -511,6 +517,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \
@@ -589,6 +596,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \
@@ -626,6 +634,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \

--- a/.github/workflows/deploy_enterprise.yml
+++ b/.github/workflows/deploy_enterprise.yml
@@ -349,7 +349,6 @@ jobs:
         run: |
             az spring app deploy \
                 --name catalog-service \
-                --build-env "-BP_JVM_VERSION 17" \
                 --jvm-options='-XX:MaxMetaspaceSize=148644K' \
                 --source-path ${{ github.workspace }}/fitness-store/apps/acme-catalog \
                 --config-file-pattern catalog
@@ -357,7 +356,6 @@ jobs:
         run: |
             az spring app deploy \
                 --name payment-service \
-                --build-env "-BP_JVM_VERSION 17" \
                 --jvm-options='-XX:MaxMetaspaceSize=148644K' \
                 --source-path ${{ github.workspace }}/fitness-store/apps/acme-payment \
                 --env "SPRING_DATASOURCE_AZURE_PASSWORDLESSENABLED=true" \

--- a/.github/workflows/deploy_standard.yml
+++ b/.github/workflows/deploy_standard.yml
@@ -581,6 +581,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \

--- a/.github/workflows/deploy_standard.yml
+++ b/.github/workflows/deploy_standard.yml
@@ -199,7 +199,6 @@ jobs:
         with:
           terraform_wrapper: false
           terraform_version: 1.5.7
-
       - name: Terraform Init
         run: |
           terraform init \
@@ -243,6 +242,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \
@@ -285,6 +285,7 @@ jobs:
               uses: hashicorp/setup-terraform@v2.0.3
               with:
                 terraform_wrapper: false
+                terraform_version: 1.5.7
             - name: Terraform Init
               run: |
                 terraform init \
@@ -327,6 +328,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \
@@ -465,6 +467,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \
@@ -505,6 +508,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \
@@ -543,6 +547,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \
@@ -621,6 +626,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \
@@ -658,6 +664,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \

--- a/.github/workflows/deploy_standard.yml
+++ b/.github/workflows/deploy_standard.yml
@@ -108,6 +108,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \

--- a/.github/workflows/deploy_standard.yml
+++ b/.github/workflows/deploy_standard.yml
@@ -387,7 +387,8 @@ jobs:
         run: |
           az extension add --name spring -y
           az spring list -o table
-
+          az account set --subscription ${{ env.ARM_SUBSCRIPTION_ID }} 
+          az configure --defaults group=${{ needs.deploy_lz_standard.outputs.spring_apps_rg }} spring=${{ needs.deploy_lz_standard.outputs.spring_apps_service_name }}
       - name: Deploy api-gateway
         run: |          
           az spring app deploy \

--- a/.github/workflows/deploy_standard.yml
+++ b/.github/workflows/deploy_standard.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Checkout this repository
         uses: actions/checkout@v3
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
           terraform_version: 1.5.7
@@ -151,6 +151,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
       - name: Terraform Init
         run: |
           terraform init \
@@ -194,9 +195,11 @@ jobs:
       - name: Checkout this repository
         uses: actions/checkout@v3
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
+          terraform_version: 1.5.7
+
       - name: Terraform Init
         run: |
           terraform init \

--- a/.github/workflows/deploy_standard.yml
+++ b/.github/workflows/deploy_standard.yml
@@ -445,7 +445,7 @@ jobs:
         build,
       ]
     runs-on: ubuntu-latest
-    if: needs.conditions.outputs.destroy == 'true'
+    if: ${{ always() && needs.conditions.outputs.destroy == 'true'}}
     env:
       NAME_PREFIX: ${{needs.conditions.outputs.name_prefix}}
       ENVIRONMENT: ${{needs.conditions.outputs.environment}}
@@ -485,7 +485,7 @@ jobs:
     needs: [conditions, deploy_lz_standard, destroy_pet_clinic_infra]
     name: Destroy 06 LZ Spring Apps Standard
     runs-on: ubuntu-latest
-    if: needs.conditions.outputs.destroy == 'true'
+    if: ${{ always() && needs.conditions.outputs.destroy == 'true'}}
     env:
       NAME_PREFIX: ${{needs.conditions.outputs.name_prefix}}
       ENVIRONMENT: ${{needs.conditions.outputs.environment}}
@@ -523,7 +523,7 @@ jobs:
     needs: [destroy_lz_standard, conditions]
     name: Destroy 05 Hub Firewall
     runs-on: ubuntu-latest
-    if: needs.conditions.outputs.destroy == 'true'
+    if: ${{ always() && needs.conditions.outputs.destroy == 'true'}}
     env:
       NAME_PREFIX: ${{needs.conditions.outputs.name_prefix}}
       ENVIRONMENT: ${{needs.conditions.outputs.environment}}
@@ -561,7 +561,7 @@ jobs:
     needs: [destroy_hub_firewall, conditions]
     name: Destroy 04 LZ Shared Resources
     runs-on: ubuntu-latest
-    if: needs.conditions.outputs.destroy == 'true'
+    if: ${{ always() && needs.conditions.outputs.destroy == 'true'}}
     env:
       NAME_PREFIX: ${{needs.conditions.outputs.name_prefix}}
       ENVIRONMENT: ${{needs.conditions.outputs.environment}}
@@ -601,7 +601,7 @@ jobs:
     needs: [destroy_lz_shared, conditions]
     name: Destroy 03 LZ Network
     runs-on: ubuntu-latest
-    if: needs.conditions.outputs.destroy == 'true'
+    if: ${{ always() && needs.conditions.outputs.destroy == 'true'}}
     env:
       NAME_PREFIX: ${{needs.conditions.outputs.name_prefix}}
       ENVIRONMENT: ${{needs.conditions.outputs.environment}}
@@ -638,7 +638,7 @@ jobs:
     name: Destroy 02 Hub Network
     needs: [destroy_lz_network, conditions]
     runs-on: ubuntu-latest
-    if: needs.conditions.outputs.destroy == 'true'
+    if: ${{ always() && needs.conditions.outputs.destroy == 'true'}}
     env:
       NAME_PREFIX: ${{needs.conditions.outputs.name_prefix}}
       ENVIRONMENT: ${{needs.conditions.outputs.environment}}

--- a/Scenarios/ASA-Secure-Baseline/Terraform/04-LZ-SharedResources/provider.tf
+++ b/Scenarios/ASA-Secure-Baseline/Terraform/04-LZ-SharedResources/provider.tf
@@ -2,8 +2,8 @@
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
-      version = "= 3.32.0"
+      source  = "hashicorp/azurerm"
+      version = "= 3.75.0"
     }
   }
 
@@ -11,18 +11,18 @@ terraform {
     # resource_group_name  = ""   # Partial configuration, provided during "terraform init"
     # storage_account_name = ""   # Partial configuration, provided during "terraform init"
     # container_name       = ""   # Partial configuration, provided during "terraform init"
-    key                  = "lz-sharedresources"
+    key = "lz-sharedresources"
   }
 
 }
 
 provider "azurerm" {
-    features {
-     resource_group {
-       prevent_deletion_if_contains_resources = false
-     }
-     log_analytics_workspace {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+    log_analytics_workspace {
       permanently_delete_on_destroy = true
-     }
-    } 
+    }
+  }
 }

--- a/Scenarios/ASA-Secure-Baseline/Terraform/09-e2e-githubaction-standard.md
+++ b/Scenarios/ASA-Secure-Baseline/Terraform/09-e2e-githubaction-standard.md
@@ -26,6 +26,36 @@ It's a great way to automate your CI/CD pipelines, and it's free for public repo
 To set up GitHub Actions for deployment, we'll need to use the new workflow file in our repository.
 This file will contain the instructions for our CI/CD pipeline.
 
+## Creating an Azure Service Principal
+
+In order to deploy our Landing Zone and application to Azure Spring Apps, we'll need to create an Azure Service Principal.
+This is an identity that can be used to authenticate to Azure, and that can be granted access to specific resources.
+
+To create a new Service Principal, run the following commands:
+
+```bash
+    SUBSCRIPTION_ID=$(
+      az account show \
+        --query id \
+        --output tsv \
+        --only-show-errors
+    )
+
+    # Modify --name to your liking - must be unique in the directory
+    AZURE_CREDENTIALS=$(
+      MSYS_NO_PATHCONV=1 az ad sp create-for-rbac \
+        --name="sp-${PROJECT}-${UNIQUE_IDENTIFIER}" \
+        --role="Owner" \
+        --scopes="/subscriptions/$SUBSCRIPTION_ID" \
+        --sdk-auth \
+        --only-show-errors
+    )
+
+    echo $AZURE_CREDENTIALS
+    echo $SUBSCRIPTION_ID     
+```
+In the next step we'll setup secrets in Github Actions to store $AZURE_CREDENTIALS securely for use by the workflow.
+
 ## Setup secrets and variables
 
 Secrets in GitHub are encrypted and allow you to store sensitive information such as passwords or API keys, and use them in your workflows using the ${{ secrets.MY_SECRET }} syntax.


### PR DESCRIPTION
Resolves and Issue where terraform would crash with latest version, pins to 1.5.7
Resolves issue with GitHub ASA deploy task causing deployment to fail due to not having access to log stream, now uses az sping app deploy CLI
Standard GitHub action workflow will now allow destroy steps to run if app deployments fail
